### PR TITLE
Correct vendor identification when parsing output of `ipmitool fru`

### DIFF
--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common/files/scripts/metal/metal-lib.sh
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common/files/scripts/metal/metal-lib.sh
@@ -232,7 +232,7 @@ function enable_amsd() {
         echo 'amsd is not installed, ignoring amsd services'
         return 0
     fi
-    echo scanning vendor ... && vendor=$(ipmitool fru | grep -i 'board mfg' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
+    echo scanning vendor ... && vendor=$(ipmitool fru | grep -i 'board mfg' | grep -v -i 'board mfg date' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
     case $vendor in
         *Marvell*|HP|HPE)
             echo Enabling iLO services for detected vendor: $vendor
@@ -324,7 +324,7 @@ Configuring UEFI boot-order...
 these use the same commands from the manual page:
     https://github.com/Cray-HPE/docs-csm/blob/main/background/ncn_boot_workflow.md#setting-order
 EOM
-    echo scanning vendor ... && vendor=$(ipmitool fru | grep -i 'board mfg' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
+    echo scanning vendor ... && vendor=$(ipmitool fru | grep -i 'board mfg' | grep -v -i 'board mfg date' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
     hostname=${hostname:-$(hostname)}
     # Add vendors here; add like-vendors on the same case statement.
     # "like-vendors" means their efibootmgr outboot matches


### PR DESCRIPTION
Signed-off-by: Douglas Jacobsen <dmjacobsen@lbl.gov>

### Summary and Scope


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes:
issue where setup_uefi_bootorder gets confused by thinking the manufacturing date is the vendor instead of the manufacturer of a given FRU.

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
